### PR TITLE
Fix vignette build failures by conditionally evaluating OmicsMLRepoRcode chunks

### DIFF
--- a/.github/workflows/rworkflows.yml
+++ b/.github/workflows/rworkflows.yml
@@ -39,8 +39,6 @@ jobs:
           rspm: ~
     steps:
     - uses: neurogenomics/rworkflows@master
-      env:
-        _R_CHECK_FORCE_SUGGESTS_: "FALSE"
       with:
         run_bioccheck: ${{ true }}
         run_rcmdcheck: ${{ true }}

--- a/.github/workflows/rworkflows.yml
+++ b/.github/workflows/rworkflows.yml
@@ -39,6 +39,8 @@ jobs:
           rspm: ~
     steps:
     - uses: neurogenomics/rworkflows@master
+      env:
+        _R_CHECK_FORCE_SUGGESTS_: "FALSE"
       with:
         run_bioccheck: ${{ true }}
         run_rcmdcheck: ${{ true }}

--- a/tests/testthat/test-curatedMetagenomicData.R
+++ b/tests/testthat/test-curatedMetagenomicData.R
@@ -112,6 +112,9 @@ test_that('first list element row names all coercible to integer when `rownames 
     returned_resources <-
         curatedMetagenomicData("HMP_2012.relative_abundance", dryrun = FALSE, counts = TRUE, rownames = "NCBI")
 
+    # Skip test if no data was returned (can happen in CI environments with network restrictions)
+    skip_if(length(returned_resources) == 0, "No data returned from ExperimentHub - skipping test")
+
     # rowData includes only IDs
     all_boolean <- lapply(rowData(returned_resources[[1L]]), function(col) is.integer(col)) |> unlist() |> all()
     expect_true(all_boolean)
@@ -131,8 +134,11 @@ test_that('first list element row names all coercible to integer when `rownames 
     resource_row_names <-
         base::rownames(returned_resources[[1]])
     ## hack to remove text from rownames
+    # Handle case where split might not have a second element
     resource_row_names <-
-        vapply(strsplit(resource_row_names, ":|_"), `[[`, character(1L), 2L)
+        vapply(strsplit(resource_row_names, ":|_"), function(x) {
+            if (length(x) >= 2L) x[[2L]] else x[[1L]]
+        }, character(1L))
 
     expect_silent(base::as.integer(resource_row_names))
 })

--- a/tests/testthat/test-curatedMetagenomicData.R
+++ b/tests/testthat/test-curatedMetagenomicData.R
@@ -112,8 +112,11 @@ test_that('first list element row names all coercible to integer when `rownames 
     returned_resources <-
         curatedMetagenomicData("HMP_2012.relative_abundance", dryrun = FALSE, counts = TRUE, rownames = "NCBI")
 
-    # Skip test if no data was returned (can happen in CI environments with network restrictions)
-    skip_if(length(returned_resources) == 0, "No data returned from ExperimentHub - skipping test")
+    expect_gt(
+        length(returned_resources),
+        0L,
+        info = "Expected at least one resource from ExperimentHub for 'HMP_2012.relative_abundance'"
+    )
 
     # rowData includes only IDs
     all_boolean <- lapply(rowData(returned_resources[[1L]]), function(col) is.integer(col)) |> unlist() |> all()
@@ -129,18 +132,10 @@ test_that('first list element row names all coercible to integer when `rownames 
     rownames(returned_resources[[1]]) <- gsub(pattern, "", rownames(returned_resources[[1]]))
     # Moreover, if there were duplicated rownames, the function added a suffix
     # (species:001, species:001_2), which is why we remove it.
-    rownames(returned_resources[[1]]) <- gsub("_\\d+$", "", rownames(returned_resources[[1]])) |> as.integer()
-
-    resource_row_names <-
-        base::rownames(returned_resources[[1]])
-    ## hack to remove text from rownames
-    # Handle case where split might not have a second element
-    resource_row_names <-
-        vapply(strsplit(resource_row_names, ":|_"), function(x) {
-            if (length(x) >= 2L) x[[2L]] else x[[1L]]
-        }, character(1L))
-
-    expect_silent(base::as.integer(resource_row_names))
+    resource_row_names <- base::rownames(returned_resources[[1]])
+    resource_row_names <- gsub(pattern, "", resource_row_names)
+    resource_row_names <- gsub("_\\d+$", "", resource_row_names)
+    expect_false(anyNA(suppressWarnings(base::as.integer(resource_row_names))))
 })
 
 test_that("first list element colData matches sampleMetadata when dataType is not relative_abundance", {

--- a/vignettes/curatedMetagenomicData.Rmd
+++ b/vignettes/curatedMetagenomicData.Rmd
@@ -198,7 +198,7 @@ The `counts` and `rownames` arguments apply to `returnSamples()` as well, and ca
 To demonstrate the utility of `r Biocpkg("curatedMetagenomicData")`, an example analysis is presented below. However, readers should know analysis is generally beyond the scope of `r Biocpkg("curatedMetagenomicData")` and the analysis presented here is for demonstration alone. It is best to consider the output of `r Biocpkg("curatedMetagenomicData")` as the input of analysis more than anything else.
 
 ## Load R packages
-```{r,include=TRUE,results="hide",message=FALSE,warning=FALSE}
+```{r,include=TRUE,results="hide",message=FALSE,warning=FALSE,eval=require("OmicsMLRepoR", quietly=TRUE)}
 library(OmicsMLRepoR)
 library(mia)
 library(scater)
@@ -210,7 +210,7 @@ library(lefser)
 ## Retrieve harmonized metadata 
 `r Biocpkg("curatedMetagenomicData")` loads the metadata table, `sampleMetadata`. For further harmonized version of the sample-level metadata will be available in the future release of this package, and currently available through `r Biocpkg("OmicsMLRepoR")` package.
 
-```{r, message = FALSE}
+```{r, message = FALSE, eval=require("OmicsMLRepoR", quietly=TRUE)}
 cmd <- OmicsMLRepoR::getMetadata("cMD")
 ```
 
@@ -222,7 +222,7 @@ In this example, we will examine the association between current smoking status 
 
 First, as above, we use the `returnSamples()` function to return the relevant samples across all studies available in `r Biocpkg("curatedMetagenomicData")`. We want healthy adults, whose smoking history is known, and only fecal samples. The `select(where...` line below removes metadata columns which are all `NA` values – they exist in another study but are all `NA` once subsetting has been done. 
 
-```{r}
+```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
 smoke <- cmd |> 
     filter(disease == "Healthy") |> 
     filter(age_group == "Adult") |>
@@ -231,13 +231,13 @@ smoke <- cmd |>
     select(where(~ !all(is.na(.x))))  # remove metadata columns which are all `NA` values
 ```
 
-```{r}
+```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
 table(smoke$smoker, useNA = "ifany")
 ```
 
 A new binary variable for smoking status, with levels `Smoker` and `Never Smoker`, is created to facilitate downstream analysis. The names of attributes are updated, so they will look nice in plots.
 
-```{r}
+```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
 smoke <- smoke %>%
   mutate(
     smoker_bin = as.factor(
@@ -250,7 +250,7 @@ table(smoke$smoker_bin, useNA = "ifany")
 
 Lastly, the `"relative_abundance"` `dataType` is requested because it contains the relevant information about microbial composition.
 
-```{r message = FALSE}
+```{r, message = FALSE, eval=require("OmicsMLRepoR", quietly=TRUE)}
 smoke_tse <- smoke %>% returnSamples("relative_abundance", rownames = "short")
 
 ## Removing samples with NA values for smoker_bin
@@ -260,7 +260,7 @@ smoke_tse <- smoke_tse[,!is.na(smoke_tse$smoker_bin)]
 ### Agglomerate By Taxonomic Rank
 The `agglomerateByRank` unction from `r Biocpkg("mia")` is used to sum up data based on associations with certain taxonomic ranks, as defined in `rowData`.
 
-```{r}
+```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
 smoke_tse_genus <- agglomerateByRank(smoke_tse, rank = "genus")
 ```
 
@@ -273,7 +273,7 @@ are they are large variety of microbial taxa present). The Shannon index
 (H’) is a commonly used measure of alpha diversity, it’s estimated here 
 using the `addAlpha()` function from the `r Biocpkg("mia")` package.
 
-```{r fig.cap = "Alpha Diversity - Shannon Index (H')"}
+```{r, fig.cap = "Alpha Diversity - Shannon Index (H')", eval=require("OmicsMLRepoR", quietly=TRUE)}
 ## Adding Shannon diversity values to colData
 smoke_shannon <- smoke_tse_genus |>
   addAlpha(assay.type = "relative_abundance", index = "shannon_diversity")
@@ -292,7 +292,7 @@ has higher alpha diversity compared to the `Smoker` group. This may serve
 as basis for further investigation as to whether smoking can lead to gut 
 microbiome dysbiosis.
 
-```{r}
+```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
 ## Test if alpha diversity between smokers and non-smokers is significantly different
 wilcox.test(shannon_diversity ~ smoker_bin, data = colData(smoke_shannon))
 ```
@@ -313,7 +313,7 @@ To quickly plot the results of beta diversity analysis,
 the `plotReducedDim()` function from the `r Biocpkg("scater")` package is 
 used along with `r CRANpkg("ggplot2")` syntax.
 
-```{r fig.cap = "Beta Diversity – Bray–Curtis PCoA"}
+```{r, fig.cap = "Beta Diversity – Bray–Curtis PCoA", eval=require("OmicsMLRepoR", quietly=TRUE)}
 smoke_tse %>% 
   agglomerateByRanks() |>
     runMDS(FUN = vegdist, method = "bray", exprs_values = "relative_abundance", altexp = "genus", name = "BrayCurtis") |>
@@ -333,7 +333,7 @@ To quickly plot the results of beta diversity analysis, the `plotReducedDim()`
 function from the `r Biocpkg("scater")` package is used along with 
 `r CRANpkg("ggplot2")` syntax again.
 
-```{r}
+```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
 smoke_tse %>%
   agglomerateByRanks() |>
     runUMAP(exprs_values = "relative_abundance", altexp = "genus", name = "UMAP") |>
@@ -350,7 +350,7 @@ groups. An example approach for differential abundance is the LEfSe analysis,
 which can be accomplished using `lefser()` and `lefserPlot()` from the 
 `r Biocpkg("lefser")` package.
 
-```{r}
+```{r, eval=require("OmicsMLRepoR", quietly=TRUE) && require("lefser", quietly=TRUE)}
 lefser(
     relativeAb(smoke_tse_genus),
     kruskal.threshold = 0.05,

--- a/vignettes/curatedMetagenomicData.Rmd
+++ b/vignettes/curatedMetagenomicData.Rmd
@@ -198,8 +198,7 @@ The `counts` and `rownames` arguments apply to `returnSamples()` as well, and ca
 To demonstrate the utility of `r Biocpkg("curatedMetagenomicData")`, an example analysis is presented below. However, readers should know analysis is generally beyond the scope of `r Biocpkg("curatedMetagenomicData")` and the analysis presented here is for demonstration alone. It is best to consider the output of `r Biocpkg("curatedMetagenomicData")` as the input of analysis more than anything else.
 
 ## Load R packages
-```{r,include=TRUE,results="hide",message=FALSE,warning=FALSE,eval=require("OmicsMLRepoR", quietly=TRUE)}
-library(OmicsMLRepoR)
+```{r,include=TRUE,results="hide",message=FALSE,warning=FALSE}
 library(mia)
 library(scater)
 library(vegan)
@@ -210,8 +209,16 @@ library(lefser)
 ## Retrieve harmonized metadata 
 `r Biocpkg("curatedMetagenomicData")` loads the metadata table, `sampleMetadata`. For further harmonized version of the sample-level metadata will be available in the future release of this package, and currently available through `r Biocpkg("OmicsMLRepoR")` package.
 
-```{r, message = FALSE, eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, include = FALSE}
+has_OmicsMLRepoR <- require("OmicsMLRepoR", quietly = TRUE)
+```
+
+```{r, message = FALSE, eval=has_OmicsMLRepoR}
 cmd <- OmicsMLRepoR::getMetadata("cMD")
+```
+
+```{r, results="asis", eval=!has_OmicsMLRepoR}
+cat("**Note:** `OmicsMLRepoR` is not installed, so the harmonized-metadata example analysis below is skipped.\n")
 ```
 
 ## Prepare Data
@@ -222,7 +229,7 @@ In this example, we will examine the association between current smoking status 
 
 First, as above, we use the `returnSamples()` function to return the relevant samples across all studies available in `r Biocpkg("curatedMetagenomicData")`. We want healthy adults, whose smoking history is known, and only fecal samples. The `select(where...` line below removes metadata columns which are all `NA` values – they exist in another study but are all `NA` once subsetting has been done. 
 
-```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, eval=has_OmicsMLRepoR}
 smoke <- cmd |> 
     filter(disease == "Healthy") |> 
     filter(age_group == "Adult") |>
@@ -231,13 +238,13 @@ smoke <- cmd |>
     select(where(~ !all(is.na(.x))))  # remove metadata columns which are all `NA` values
 ```
 
-```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, eval=has_OmicsMLRepoR}
 table(smoke$smoker, useNA = "ifany")
 ```
 
 A new binary variable for smoking status, with levels `Smoker` and `Never Smoker`, is created to facilitate downstream analysis. The names of attributes are updated, so they will look nice in plots.
 
-```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, eval=has_OmicsMLRepoR}
 smoke <- smoke %>%
   mutate(
     smoker_bin = as.factor(
@@ -250,7 +257,7 @@ table(smoke$smoker_bin, useNA = "ifany")
 
 Lastly, the `"relative_abundance"` `dataType` is requested because it contains the relevant information about microbial composition.
 
-```{r, message = FALSE, eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, message = FALSE, eval=has_OmicsMLRepoR}
 smoke_tse <- smoke %>% returnSamples("relative_abundance", rownames = "short")
 
 ## Removing samples with NA values for smoker_bin
@@ -260,7 +267,7 @@ smoke_tse <- smoke_tse[,!is.na(smoke_tse$smoker_bin)]
 ### Agglomerate By Taxonomic Rank
 The `agglomerateByRank` unction from `r Biocpkg("mia")` is used to sum up data based on associations with certain taxonomic ranks, as defined in `rowData`.
 
-```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, eval=has_OmicsMLRepoR}
 smoke_tse_genus <- agglomerateByRank(smoke_tse, rank = "genus")
 ```
 
@@ -273,7 +280,7 @@ are they are large variety of microbial taxa present). The Shannon index
 (H’) is a commonly used measure of alpha diversity, it’s estimated here 
 using the `addAlpha()` function from the `r Biocpkg("mia")` package.
 
-```{r, fig.cap = "Alpha Diversity - Shannon Index (H')", eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, fig.cap = "Alpha Diversity - Shannon Index (H')", eval=has_OmicsMLRepoR}
 ## Adding Shannon diversity values to colData
 smoke_shannon <- smoke_tse_genus |>
   addAlpha(assay.type = "relative_abundance", index = "shannon_diversity")
@@ -292,7 +299,7 @@ has higher alpha diversity compared to the `Smoker` group. This may serve
 as basis for further investigation as to whether smoking can lead to gut 
 microbiome dysbiosis.
 
-```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, eval=has_OmicsMLRepoR}
 ## Test if alpha diversity between smokers and non-smokers is significantly different
 wilcox.test(shannon_diversity ~ smoker_bin, data = colData(smoke_shannon))
 ```
@@ -313,7 +320,7 @@ To quickly plot the results of beta diversity analysis,
 the `plotReducedDim()` function from the `r Biocpkg("scater")` package is 
 used along with `r CRANpkg("ggplot2")` syntax.
 
-```{r, fig.cap = "Beta Diversity – Bray–Curtis PCoA", eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, fig.cap = "Beta Diversity – Bray–Curtis PCoA", eval=has_OmicsMLRepoR}
 smoke_tse %>% 
   agglomerateByRanks() |>
     runMDS(FUN = vegdist, method = "bray", exprs_values = "relative_abundance", altexp = "genus", name = "BrayCurtis") |>
@@ -333,7 +340,7 @@ To quickly plot the results of beta diversity analysis, the `plotReducedDim()`
 function from the `r Biocpkg("scater")` package is used along with 
 `r CRANpkg("ggplot2")` syntax again.
 
-```{r, eval=require("OmicsMLRepoR", quietly=TRUE)}
+```{r, eval=has_OmicsMLRepoR}
 smoke_tse %>%
   agglomerateByRanks() |>
     runUMAP(exprs_values = "relative_abundance", altexp = "genus", name = "UMAP") |>
@@ -350,7 +357,7 @@ groups. An example approach for differential abundance is the LEfSe analysis,
 which can be accomplished using `lefser()` and `lefserPlot()` from the 
 `r Biocpkg("lefser")` package.
 
-```{r, eval=require("OmicsMLRepoR", quietly=TRUE) && require("lefser", quietly=TRUE)}
+```{r, eval=has_OmicsMLRepoR && require("lefser", quietly=TRUE)}
 lefser(
     relativeAb(smoke_tse_genus),
     kruskal.threshold = 0.05,


### PR DESCRIPTION
All code chunks that use `OmicsMLRepoR` (a Suggests package) are now wrapped with `eval=require('OmicsMLRepoR', quietly=TRUE`) to allow vignette building in environments where the package is not installed. This fixes the failed actions on all three platforms (Windows, macOS, Ubuntu) that were failing with '`there is no package called OmicsMLRepoR`' error.

I just hope that this will fix the failed jobs



