### PR TITLE
fix: return mergeList if it is already a SummarizedExperiment (fixes #321)

### DIFF
--- a/R/mergeData.R
+++ b/R/mergeData.R
@@ -64,7 +64,7 @@
 #' @importFrom TreeSummarizedExperiment TreeSummarizedExperiment
 #' @importFrom SummarizedExperiment SummarizedExperiment
 mergeData <- function(mergeList) {
-    if (is(mergeList, "SummarizedExperiment")) {
+    if (methods::is(mergeList, "SummarizedExperiment")) {
         return(mergeList)
     }
 

--- a/R/mergeData.R
+++ b/R/mergeData.R
@@ -64,6 +64,10 @@
 #' @importFrom TreeSummarizedExperiment TreeSummarizedExperiment
 #' @importFrom SummarizedExperiment SummarizedExperiment
 mergeData <- function(mergeList) {
+    if (is(mergeList, "SummarizedExperiment")) {
+        return(mergeList)
+    }
+
     if (length(mergeList) == 1) {
         return(mergeList[[1]])
     }

--- a/tests/testthat/test-mergeData.R
+++ b/tests/testthat/test-mergeData.R
@@ -5,6 +5,15 @@ test_that("merge result is the equal to the first element of mergeList when its 
     expect_equal(mergeData(merge_list), merge_list[[1]])
 })
 
+test_that("merge result is the input itself when mergeList is a SummarizedExperiment", {
+    merge_list <-
+        curatedMetagenomicData("AsnicarF_2017.relative_abundance", dryrun = FALSE, counts = FALSE)
+
+    se <- merge_list[[1]]
+    expect_equal(mergeData(se), se)
+})
+
+
 test_that("cannot merge list elements when dataType is different", {
     merge_list <-
         curatedMetagenomicData("HMP_2012.marker_", dryrun = FALSE, counts = FALSE)

--- a/tests/testthat/test-mergeData.R
+++ b/tests/testthat/test-mergeData.R
@@ -5,12 +5,13 @@ test_that("merge result is the equal to the first element of mergeList when its 
     expect_equal(mergeData(merge_list), merge_list[[1]])
 })
 
-test_that("merge result is the input itself when mergeList is a SummarizedExperiment", {
+test_that("merge result is the input itself when mergeList is a TreeSummarizedExperiment", {
     merge_list <-
         curatedMetagenomicData("AsnicarF_2017.relative_abundance", dryrun = FALSE, counts = FALSE)
 
-    se <- merge_list[[1]]
-    expect_equal(mergeData(se), se)
+    tse <- merge_list[[1]]
+    expect_s4_class(tse, "TreeSummarizedExperiment")
+    expect_identical(mergeData(tse), tse)
 })
 
 


### PR DESCRIPTION
This PR fixes issue #321 where calling mergeData on a TreeSummarizedExperiment fails. It also adds a unit test.