### PR TITLE
Refactor: inline curatedCore functions and fix ADR references

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,4 +10,4 @@
 ^vignettes/articles$
 ^\.github$
 ^\.Rproj\.user$
-^\.github/instructions$
+

--- a/.github/adr/0000-record-architecture-decisions.md
+++ b/.github/adr/0000-record-architecture-decisions.md
@@ -17,9 +17,9 @@ reasoning.
 ## Decision
 
 We will record architecturally significant decisions as **Architecture Decision
-Records (ADRs)** stored in `docs/adr/`, using a lightweight Nygard-style format
+Records (ADRs)** stored in `.github/adr/`, using a lightweight Nygard-style format
 (context / decision / alternatives / consequences). The process and index live
-in `docs/adr/README.md`. ADRs are immutable once accepted; a changed decision is
+in `.github/adr/README.md`. ADRs are immutable once accepted; a changed decision is
 captured by a new ADR that supersedes the old one.
 
 ## Alternatives considered
@@ -44,4 +44,4 @@ captured by a new ADR that supersedes the old one.
 ## References
 
 - Michael Nygard, "Documenting Architecture Decisions" (2011).
-- `docs/adr/README.md` for the process and index.
+- `.github/adr/README.md` for the process and index.

--- a/.github/instructions/20-development.md
+++ b/.github/instructions/20-development.md
@@ -18,7 +18,7 @@ No new exported S4 classes; returns imported (Tree)SummarizedExperiment.
 ## Key Dependencies
 
 - SummarizedExperiment, TreeSummarizedExperiment
-- curatedCore, DBI, duckdb, dplyr, tidyr, purrr
+- DBI, duckdb, dplyr, tidyr, purrr
 - mia
 
 ## Code Style Notes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,13 +57,13 @@ Depends:
     SummarizedExperiment,
     TreeSummarizedExperiment
 Imports:
-    curatedCore,
     DBI,
     S4Vectors,
     dbplyr,
     dplyr,
     duckdb,
     magrittr,
+    methods,
     mia,
     purrr,
     rlang,
@@ -72,8 +72,6 @@ Imports:
     tidyr,
     tidyselect,
     utils
-Remotes:
-    waldronlab/curatedCore
 Suggests:
     BiocStyle,
     DT,

--- a/R/cmd4.R
+++ b/R/cmd4.R
@@ -48,11 +48,8 @@
 }
 
 ## ---- DuckDB connection ----------------------------------------------------
-
-.cmd_connect <- function(db_url = .cmd_data_url(), alias = "cmgd") {
-    src <- curatedCore::duckdbCatalogSource(db_url, alias = alias)
-    curatedCore::connectSource(src)
-}
+## .cmd_connect() and .cmd_disconnect() live in R/duckdb-connection.R
+## .filter_view() and .collect_view() live in R/duckdb-query.R
 
 ## ---- assay retrieval ------------------------------------------------------
 
@@ -83,13 +80,13 @@
 
     sample_names <- unique(as.character(sample_names))
 
-    ## Use curatedCore for lazy filtering and collection
-    lazy <- curatedCore::filterView(
+    ## Lazy-filter the view and collect results
+    lazy <- .filter_view(
         con, view_name,
         filter_values = list(sample_name = sample_names)
     )
     long <- dplyr::select(
-        curatedCore::collectView(lazy, notify = FALSE),
+        .collect_view(lazy, notify = FALSE),
         "sample_name",
         feature = !!rlang::sym(feature_col),
         value   = !!rlang::sym(value_col)

--- a/R/curatedMetagenomicData.R
+++ b/R/curatedMetagenomicData.R
@@ -90,7 +90,7 @@ curatedMetagenomicData <- function(pattern, dryrun = TRUE,
     names(resource_list) <- matched
 
     con <- .cmd_connect()
-    on.exit(curatedCore::closeSource(con), add = TRUE)
+    on.exit(.cmd_disconnect(con), add = TRUE)
 
     for (i in seq_len(nrow(parts))) {
         study   <- parts[[i, "study_name"]]

--- a/R/duckdb-connection.R
+++ b/R/duckdb-connection.R
@@ -1,0 +1,76 @@
+### DuckDB catalog connection helpers (internal) -----------------------------
+###
+### Inlined from curatedCore::source.R. Since curatedMetagenomicData only
+### ever connects to a DuckDB catalog, the multi-backend CuratedSource S4
+### class and dispatch are replaced with a single .cmd_connect() function.
+
+## ---- S3 endpoint configuration --------------------------------------------
+
+## Configure the DuckDB httpfs S3 client for a catalog host.
+## Parses scheme and host from a catalog URL and, for HTTP(S) catalogs,
+## points DuckDB's httpfs S3 client at that host so the catalog's s3://
+## view references resolve back to it.
+##
+## @param con A DuckDB connection.
+## @param url character(1). The catalog URL.
+## @return NULL, invisibly.
+## @importFrom DBI dbExecute
+.configure_s3 <- function(con, url) {
+    scheme_match <- regmatches(
+        url,
+        regexpr("^(https?)://([^/]+)", url, ignore.case = TRUE)
+    )
+    if (length(scheme_match) == 1L) {
+        parts <- regmatches(
+            scheme_match,
+            regexec("^(https?)://([^/]+)", scheme_match, ignore.case = TRUE)
+        )[[1L]]
+        scheme <- tolower(parts[2L])
+        endpoint <- parts[3L]
+        DBI::dbExecute(con, sprintf("SET s3_endpoint='%s';", endpoint))
+        DBI::dbExecute(con, "SET s3_url_style='path';")
+        DBI::dbExecute(
+            con,
+            sprintf("SET s3_use_ssl=%s;",
+                if (scheme == "https") "true" else "false")
+        )
+    }
+    invisible(NULL)
+}
+
+## ---- DuckDB catalog connection --------------------------------------------
+
+## Open an in-memory DuckDB connection, install and load the httpfs
+## extension, configure the S3 client for the catalog host, attach the
+## catalog read-only, and USE it. This replaces the curatedCore pattern of
+## duckdbCatalogSource() + connectSource() with a single direct call.
+##
+## @param db_url character(1). URL or path of the .duckdb catalog file.
+## @param alias character(1). DuckDB alias for the attached catalog.
+## @return An open DuckDB connection (DBIConnection).
+## @importFrom DBI dbConnect dbExecute
+## @importFrom duckdb duckdb
+.cmd_connect <- function(db_url = .cmd_data_url(), alias = "cmgd") {
+    con <- DBI::dbConnect(duckdb::duckdb(), dbdir = ":memory:")
+    DBI::dbExecute(con, "INSTALL httpfs; LOAD httpfs;")
+    .configure_s3(con, db_url)
+    DBI::dbExecute(con, sprintf("ATTACH '%s' AS %s (READ_ONLY);",
+        db_url, alias))
+    DBI::dbExecute(con, sprintf("USE %s;", alias))
+    con
+}
+
+## ---- DuckDB disconnect ----------------------------------------------------
+
+## Disconnect and shut down a DuckDB connection. Wrapped in try() so it is
+## safe to call on an already-closed connection.
+##
+## @param con A DuckDB connection.
+## @return NULL, invisibly.
+## @importFrom DBI dbDisconnect
+.cmd_disconnect <- function(con) {
+    suppressWarnings(
+        try(DBI::dbDisconnect(con, shutdown = TRUE), silent = TRUE)
+    )
+    invisible(NULL)
+}

--- a/R/duckdb-query.R
+++ b/R/duckdb-query.R
@@ -1,0 +1,185 @@
+### DuckDB view query helpers (internal) -------------------------------------
+###
+### Inlined from curatedCore::query.R and curatedCore::validators.R.
+### All functions are internal (not exported, dot-prefixed). The SchemaSpec
+### parameter is dropped; CMD hardcodes its id_col via cmd4_data_types.csv.
+
+## ---- input validators -----------------------------------------------------
+
+## Validate a DuckDB connection object.
+## @param con Object to validate.
+## @return NULL, invisibly. Throws an error if con is not a DuckDB connection.
+## @noRd
+.confirm_duckdb_con <- function(con) {
+    if (!methods::is(con, "duckdb_connection")) {
+        stop("Please provide a valid 'duckdb_connection' object.",
+            call. = FALSE)
+    }
+    invisible(NULL)
+}
+
+## Validate a DuckDB lazy view/table object.
+## @param view Object to validate.
+## @return NULL, invisibly.
+## @noRd
+.confirm_duckdb_view <- function(view) {
+    if (!methods::is(view, "tbl_duckdb_connection")) {
+        stop("Please provide a valid object of the class ",
+            "'tbl_duckdb_connection'.", call. = FALSE)
+    }
+    invisible(NULL)
+}
+
+## Validate a filter_values argument.
+## @param filter_values A named list (column to values) or NULL.
+## @return NULL, invisibly. Throws an error if invalid.
+## @noRd
+.confirm_filter_values <- function(filter_values) {
+    if (!is.null(filter_values) &&
+        (!is.list(filter_values) || is.null(names(filter_values)))) {
+        stop("'filter_values' must be a named list of column = values",
+            call. = FALSE)
+    }
+    invisible(NULL)
+}
+
+## ---- projection selection -------------------------------------------------
+
+## Choose the most appropriate DuckDB view for a feature.
+##
+## Given a connection, a base view name, and an optional feature/id column
+## to filter by, return the name of the most appropriate available view.
+## When a projection named <base>_<feature> exists it is preferred;
+## otherwise a view containing the id_col is used, falling back to the
+## base view itself.
+##
+## @param con A DuckDB connection.
+## @param view_name character(1). Base view name for a data type.
+## @param feature character(1) or NULL. Feature/column to sort by.
+## @param id_col character(1). Canonical sample-identity column.
+## @return character(1). The chosen view name.
+## @importFrom DBI dbListTables
+## @noRd
+.pick_projection <- function(con, view_name, feature = NULL,
+                             id_col = "sample_name") {
+    .confirm_duckdb_con(con)
+    tbs <- DBI::dbListTables(con)
+
+    matching <- tbs[tbs == view_name |
+        startsWith(tbs, paste0(view_name, "_"))]
+    if (length(matching) == 0L) {
+        stop("'", view_name, "' does not match any existing views.",
+            call. = FALSE)
+    }
+
+    if (!is.null(feature)) {
+        eview <- paste0(view_name, "_", feature)
+        if (eview %in% matching) {
+            return(eview)
+        }
+    }
+
+    if (view_name %in% matching) {
+        return(view_name)
+    }
+    id_views <- matching[grepl(id_col, matching)]
+    if (length(id_views) > 0L) {
+        return(id_views[1L])
+    }
+    matching[1L]
+}
+
+## ---- lazy filtering -------------------------------------------------------
+
+## Filter a DuckDB view, pushing predicates down to DuckDB.
+##
+## Given a connection and the base view name for a data type, selects an
+## appropriate projection (via .pick_projection()) and applies an ordered
+## set of exact filters. Filters are applied most-selective-first, and the
+## first column is filtered using the union_all optimization to encourage
+## index/partition pruning. The result is a lazy tbl; nothing is
+## materialized until .collect_view().
+##
+## @param con A DuckDB connection.
+## @param view_name character(1). Base view name for a data type.
+## @param filter_values Named list (column to exact values) or NULL.
+## @return A lazy tbl_duckdb_connection object.
+## @importFrom dplyr tbl filter union_all collapse
+## @importFrom rlang sym
+## @noRd
+.filter_view <- function(con, view_name, filter_values = NULL) {
+    .confirm_duckdb_con(con)
+    .confirm_filter_values(filter_values)
+
+    if (is.null(filter_values) || length(filter_values) == 0L) {
+        projection <- .pick_projection(con, view_name)
+        return(dplyr::tbl(con, projection))
+    }
+
+    ## Order filter columns by selectivity (fewest values first).
+    lengths <- vapply(filter_values, length, integer(1L))
+    if (any(lengths == 0L)) {
+        projection <- .pick_projection(con, view_name)
+        return(dplyr::filter(dplyr::tbl(con, projection), FALSE))
+    }
+    sorted_inds <- order(lengths)
+    sorted_args <- filter_values[sorted_inds]
+
+    projection <- .pick_projection(con, view_name,
+        feature = names(sorted_args)[1L])
+    view <- dplyr::tbl(con, projection)
+
+    col_order <- names(sorted_args)
+    first_col <- col_order[1L]
+    first_vals <- sorted_args[[first_col]]
+
+    if (length(first_vals) == 1L) {
+        result <- dplyr::filter(view,
+            !!rlang::sym(first_col) == first_vals) |>
+            dplyr::collapse()
+        remaining_cols <- setdiff(col_order, first_col)
+    } else if (length(first_vals) <= 10L) {
+        parts <- lapply(first_vals, function(val) {
+            dplyr::filter(view, !!rlang::sym(first_col) == val)
+        })
+        result <- Reduce(dplyr::union_all, parts)
+        remaining_cols <- setdiff(col_order, first_col)
+    } else {
+        result <- view
+        remaining_cols <- col_order
+    }
+
+    for (col in remaining_cols) {
+        vals <- sorted_args[[col]]
+        if (length(vals) == 1L) {
+            result <- dplyr::filter(result, !!rlang::sym(col) == vals)
+        } else {
+            result <- dplyr::filter(result, !!rlang::sym(col) %in% vals)
+        }
+    }
+
+    result
+}
+
+## ---- collection -----------------------------------------------------------
+
+## Collect a lazy DuckDB view into a tibble.
+##
+## Materializes a lazy tbl with dplyr::collect(). When notify is TRUE, a
+## generic message is emitted if the pull is large, since collecting many
+## rows (especially over a network) can be slow.
+##
+## @param lazy A lazy tbl_duckdb_connection object.
+## @param notify logical(1). Emit a message for large pulls.
+## @return A tibble.
+## @importFrom dplyr collect
+## @noRd
+.collect_view <- function(lazy, notify = TRUE) {
+    .confirm_duckdb_view(lazy)
+    collected <- dplyr::collect(lazy)
+    if (isTRUE(notify) && nrow(collected) > 1e6L) {
+        message("Collected ", nrow(collected), " rows; large pulls can be ",
+            "slow and memory-intensive, especially over a network.")
+    }
+    collected
+}

--- a/R/returnSamples.R
+++ b/R/returnSamples.R
@@ -82,7 +82,7 @@ returnSamples <- function(sampleMetadata, dataType,
     rownames(coldata_df) <- sample_ids
 
     con <- .cmd_connect()
-    on.exit(curatedCore::closeSource(con), add = TRUE)
+    on.exit(.cmd_disconnect(con), add = TRUE)
 
     assay_mat <- .cmd_load_assay(
         con          = con,


### PR DESCRIPTION
This PR is against pr-325. It inlines curatedCore functions to remove external dependencies, fixes references to ADRs and .github, and applies code review suggestions.